### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contributing
 
 Contributing to Phys.JS is simple and easy. Just be sure to use the guidelines, and utilize the tools we used to create this library.
 
-##Guidelines
+## Guidelines
 
 When contributing please make sure you're using our guidelines:
 
@@ -15,7 +15,7 @@ When contributing please make sure you're using our guidelines:
 
 Please read some of our code before hand to get a feel for the syntax we use.
 
-##Physics
+## Physics
 
 You don't have to be extremely qualified in Physics to contribute to our library, nor even a Ph.D or Masters student in Physics (we aren't either!). But you just have to be passionate about Physics and have a general understanding of the formulas you're contributing to this library.
 <br><br>
@@ -30,7 +30,7 @@ If your ideas don't fit under these categories, then let us know!
     - Atomic and Nuclear Physics
     - Quantum Physics
 
-##Development
+## Development
 
 Here are a few commands that will help you get started development for our Library:
 
@@ -43,7 +43,7 @@ Using Node.JS you can use the Library and check your development pretty easily:
 `node index.js`
 `node lib/phys.js`
 
-###Tools
+### Tools
 
 Here are some tools we use while development Phys.JS:
 
@@ -53,7 +53,7 @@ Here are some tools we use while development Phys.JS:
 - Browserify
 - Uglifyjs
 
-##Generating for the Browser
+## Generating for the Browser
 
 Add this to `index.js` if you want to generate the docs for the browser:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Phys is a library created for individuals who want to use simple or advanced phy
 
 The APIs will allow you to understand the usage of each function, while also being able to access each constant and each function defined in the library, and apply them in your work.
 
-###[Uses](http://www.physjs.com/docs/index.html)
+### [Uses](http://www.physjs.com/docs/index.html)
 
 Phys is a module in node so it's pretty simple to integrate and start using with your current application. With node you're able to install the library as follows:
 
@@ -53,7 +53,7 @@ You'll know the inputs you've to put in very quickly, as well as what the operat
 
 This is to allow individuals to build applications that aren't just specific to calculations in Physics, but resources that would let other individuals understand Physics.
 
-##Using in Browser
+## Using in Browser
 
 Importing this into your HTML file:
 
@@ -64,7 +64,7 @@ Then to get values you can do:
 
     console.log(phys.basic.changein(2, 3));
 
-###Build
+### Build
 
 To get the dependencies for our project run:
 
@@ -76,7 +76,7 @@ To generate the Javascript file into the /src/ run:
 
 It will compile and generate the Javascript code in: /src/phys.js & the minified file in /src/phys.min.js.
 
-###Tests
+### Tests
 
 Test for the different functions in the Phys Library. To run the tests install Mocha, and then run:
 
@@ -84,13 +84,13 @@ Test for the different functions in the Phys Library. To run the tests install M
 
 It will automatically test the different sections of the library, and display the results on the Terminal.
 
-##Docs
+## Docs
 
 If you want to make the docs then run:
 
     make docs
 
-##Constants
+## Constants
 
 If you need extra precision in your answers feel free to alter these following files that contain the values for our precision:
 
@@ -99,7 +99,7 @@ If you need extra precision in your answers feel free to alter these following f
 - phys/constants/multiplier.js
 - phys/constants/units.js
 
-###Core Team
+### Core Team
 
 * Abhi Agarwal - [@abhiagarwal](http://twitter.com/abhiagarwal)
 * Philip Ottesen - [@pjo256](http://github.com/pjo256)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
